### PR TITLE
fix: improve remote selection for repositories with origin and upstream

### DIFF
--- a/internal/worktree/creator.go
+++ b/internal/worktree/creator.go
@@ -95,13 +95,23 @@ func (c *Creator) Create(worktreePath string, pr *github.PullRequest, opts *Chec
 
 func (c *Creator) findBaseRemote() *git.Remote {
 	repoName := c.repo.Name
+	repoOwner := c.repo.Owner
 	
+	// First, try to find the exact match with owner/name
+	for _, remote := range c.remotes {
+		if strings.Contains(remote.URL, repoOwner) && strings.Contains(remote.URL, repoName) {
+			return remote
+		}
+	}
+	
+	// If no exact match, prefer origin if it contains the repo name
 	for _, remote := range c.remotes {
 		if remote.Name == "origin" && strings.Contains(remote.URL, repoName) {
 			return remote
 		}
 	}
 	
+	// Otherwise, any remote with the repo name
 	for _, remote := range c.remotes {
 		if strings.Contains(remote.URL, repoName) {
 			return remote


### PR DESCRIPTION
## Summary
- Fixes remote selection logic when a repository has both `origin` (fork) and `upstream` (main repo)
- Prioritizes remotes that match both owner and repository name

## Test plan
- [x] Tested with vuln-list-update repository that has both origin and upstream remotes
- [x] Verified PR #357 can be checked out successfully
- [x] All existing tests pass

## Problem
When a repository has both:
- `origin` pointing to a user's fork
- `upstream` pointing to the main repository

The extension would try to fetch PRs from `origin` (the fork) even when the PR exists on `upstream` (main repo), resulting in:
```
fatal: couldn't find remote ref refs/pull/357/head
```

## Solution
Modified `findBaseRemote()` to prioritize remotes that match both the repository owner and name, ensuring PRs are fetched from the correct remote.