### PR TITLE
feat: add --force flag to remove command

### DIFF
--- a/internal/worktree/worktree.go
+++ b/internal/worktree/worktree.go
@@ -128,8 +128,14 @@ func GetPRTitle(worktreePath, branchName string) string {
 }
 
 // Remove removes a worktree
-func Remove(worktreePath string) error {
-	cmd := exec.Command("git", "worktree", "remove", worktreePath)
+func Remove(worktreePath string, force bool) error {
+	args := []string{"worktree", "remove"}
+	if force {
+		args = append(args, "--force")
+	}
+	args = append(args, worktreePath)
+	
+	cmd := exec.Command("git", args...)
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
 	return cmd.Run()

--- a/internal/worktree/worktree_test.go
+++ b/internal/worktree/worktree_test.go
@@ -160,7 +160,7 @@ func TestRemove(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			err := Remove(tt.worktreePath)
+			err := Remove(tt.worktreePath, false)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("Remove(%s) error = %v, wantErr %v", tt.worktreePath, err, tt.wantErr)
 			}


### PR DESCRIPTION
## Summary
- Add `--force`/`-f` flag to the remove command
- Allows removing worktrees with uncommitted changes without confirmation
- Matches the behavior of `git worktree remove --force`

## Test plan
- [x] Created worktrees with uncommitted/staged changes
- [x] Verified removal fails without --force flag
- [x] Verified removal succeeds with --force flag
- [x] Tested both long form (--force) and short form (-f)
- [x] Verified worktrees are completely removed from filesystem and git