### PR TITLE
feat: add shell mode to checkout command for ghwc function

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,12 +103,18 @@ parent-directory/
 
 ## Shell Integration
 
-For the best experience, add this shell function to your `~/.bashrc` or `~/.zshrc`:
+For the best experience, add these shell functions to your `~/.bashrc` or `~/.zshrc`:
 
 ```bash
 # Quick worktree switcher
 ghws() { 
   local target=$(gh worktree pr switch --shell "$@")
+  [ -n "$target" ] && cd "$target"
+}
+
+# Checkout and cd into new worktree
+ghwc() { 
+  local target=$(gh worktree pr checkout --shell "$@")
   [ -n "$target" ] && cd "$target"
 }
 ```
@@ -120,6 +126,12 @@ ghws
 
 # Switch to specific PR
 ghws 1234
+
+# Interactive checkout and cd
+ghwc
+
+# Checkout specific PR and cd
+ghwc 1234
 ```
 
 ## How It Works

--- a/internal/worktree/creator.go
+++ b/internal/worktree/creator.go
@@ -17,6 +17,7 @@ type CheckoutOptions struct {
 	Force             bool
 	Detach            bool
 	BranchName        string
+	ShellMode         bool
 }
 
 // Creator handles worktree creation logic


### PR DESCRIPTION
## Summary
- Add `--shell` flag to checkout command that outputs only the worktree path
- Enable creation of `ghwc` shell function for checkout and cd in one command
- Update README with `ghwc` shell function example

## Test plan
- [ ] Build the extension locally
- [ ] Test `gh worktree pr checkout --shell <pr-number>` outputs path only
- [ ] Test shell function works: `ghwc <pr-number>` checkouts and cd's
- [ ] Test interactive mode: `ghwc` without arguments
- [ ] Test cancellation in shell mode outputs nothing