### PR TITLE
fix: suppress all output except path in shell mode

### DIFF
--- a/internal/git/git.go
+++ b/internal/git/git.go
@@ -89,11 +89,10 @@ func GetBranchName(worktreePath string) string {
 func ExecuteCommands(cmdQueue [][]string) error {
 	for _, args := range cmdQueue {
 		cmd := exec.Command("git", args...)
-		cmd.Stdout = os.Stdout
-		cmd.Stderr = os.Stderr
-
-		if err := cmd.Run(); err != nil {
-			return fmt.Errorf("failed to execute git %s: %w", strings.Join(args, " "), err)
+		// Don't output to stdout/stderr to avoid interfering with shell mode
+		output, err := cmd.CombinedOutput()
+		if err != nil {
+			return fmt.Errorf("failed to execute git %s: %w (output: %s)", strings.Join(args, " "), err, string(output))
 		}
 	}
 	return nil


### PR DESCRIPTION
## Summary
- Fixed shell mode (`--shell`) to suppress all output except the worktree path
- This allows the `ghwc` shell function to work correctly without log message interference

## Problem
The `--shell` flag was added to support shell functions like:
```bash
ghwc() { 
  local target=$(gh worktree pr checkout --shell "$@")
  [ -n "$target" ] && cd "$target"
}
```

However, error messages and usage information were still being printed, which would cause the `cd` command to fail with unexpected input.

## Solution
- Added global `shellMode` variable to track when shell mode is active
- Suppress error output in `main()` when in shell mode
- Set `SilenceUsage` and `SilenceErrors` on cobra commands in shell mode
- When a worktree already exists in shell mode, output the path instead of failing

## Test plan
After this PR is merged, we can test:
```bash
# Define the shell function
ghwc() { 
  local target=$(gh worktree pr checkout --shell "$@")
  [ -n "$target" ] && cd "$target"
}

# Test cases:
ghwc 6        # Should checkout this PR
ghwc 6        # Should cd to existing worktree
ghwc 99999    # Should fail silently without cd
```