### PR TITLE
feat: add support for local development worktrees

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,16 +1,20 @@
 # gh-worktree
 
-A GitHub CLI extension for managing git worktrees with pull requests.
+A GitHub CLI extension for managing git worktrees with pull requests and local development branches.
 
-Instead of checking out pull requests in your current directory, this extension creates dedicated worktrees in a separate directory with a clear naming convention (`../repo-name-pr1234`).
+Instead of checking out pull requests in your current directory, this extension creates dedicated worktrees in separate directories:
+- PR worktrees: `../repo-name-pr1234`
+- Branch worktrees: `../repo-name-feature-name`
 
 ## Features
 
 - 🌳 **Create worktrees for PRs** - Each PR gets its own isolated working directory
-- 🔄 **Switch between worktrees** - Quick navigation between different PR worktrees
+- 🔧 **Create worktrees for local development** - Work on features before creating PRs
+- ⬆️ **Promote branch worktrees to PR worktrees** - Link local branches to PRs after creation
+- 🔄 **Switch between all worktrees** - Quick navigation between PR, branch, and main worktrees
 - 🗑️ **Clean removal** - Remove worktrees and associated branches in one command
-- 📋 **List all PR worktrees** - See all your PR worktrees at a glance
-- 🎯 **Interactive selection** - Use arrow keys and filtering to select PRs
+- 📋 **List all worktrees** - See all your PR and branch worktrees at a glance
+- 🎯 **Interactive selection** - Use arrow keys and filtering to select from all worktrees
 
 ## Installation
 
@@ -22,7 +26,7 @@ gh extension install knqyf263/gh-worktree
 
 ### `gh worktree pr checkout`
 
-Create a new worktree for a pull request.
+Create a new worktree for a pull request or local development.
 
 ```bash
 # Interactive selection from open PRs
@@ -33,20 +37,31 @@ gh worktree pr checkout 1234
 
 # Checkout specific PR by URL
 gh worktree pr checkout https://github.com/owner/repo/pull/1234
+
+# Create a new branch worktree for local development
+gh worktree pr checkout --create feature-auth
+gh worktree pr checkout -c feature-auth
 ```
 
 **Example Output:**
 ```
 Created worktree for #1234 at ../repo-name-pr1234
 Title: Add new feature for user management
+
+# Or for branch worktrees:
+Created worktree for branch 'feature-auth' at ../repo-name-feature-auth
 ```
 
 ### `gh worktree pr list`
 
-List all existing PR worktrees.
+List PR worktrees or all worktrees.
 
 ```bash
+# List only PR worktrees (default)
 gh worktree pr list
+
+# List all worktrees (PR and branch)
+gh worktree pr list --all
 ```
 
 **Example Output:**
@@ -54,24 +69,55 @@ gh worktree pr list
 PR worktrees:
   #1234	feature-branch	Add new feature for user management	../repo-name-pr1234
   #5678	bugfix-branch	Fix critical security vulnerability	../repo-name-pr5678
+
+Branch worktrees:
+  feature-auth	(local development)	../repo-name-feature-auth
+  experiment-api	(local development)	../repo-name-experiment-api
 ```
 
 ### `gh worktree pr remove`
 
-Remove a PR worktree and its associated branch.
+Remove a PR or branch worktree and its associated branch.
 
 ```bash
-# Interactive selection
+# Interactive selection (shows all worktrees)
 gh worktree pr remove
 
 # Remove specific PR worktree
 gh worktree pr remove 1234
+
+# Remove specific branch worktree
+gh worktree pr remove feature-auth
 ```
 
 **Example Output:**
 ```
 Removed worktree for #1234 at ../repo-name-pr1234
 Title: Add new feature for user management
+
+# Or for branch worktrees:
+Removed worktree for branch 'feature-auth' at ../repo-name-feature-auth
+```
+
+### `gh worktree pr promote`
+
+Promote a branch worktree to a PR worktree after creating a pull request.
+
+```bash
+# Promote current branch (auto-detects branch and PR number)
+gh worktree pr promote
+
+# Promote specific branch (auto-detects PR number)
+gh worktree pr promote feature-auth
+
+# Promote with explicit PR number
+gh worktree pr promote feature-auth 1234
+```
+
+**Example Output:**
+```
+Promoted worktree for branch 'feature-auth' to PR #1234
+Title: Add authentication system
 ```
 
 ### `gh worktree pr switch`
@@ -89,6 +135,27 @@ gh worktree pr switch 1234
 gh worktree pr switch --shell 1234
 ```
 
+### `gh worktree switch` (Unified Switcher)
+
+Switch to any worktree (PR, branch, or main).
+
+```bash
+# Interactive selection from all worktrees
+gh worktree switch
+
+# Switch to specific PR worktree
+gh worktree switch 1234
+
+# Switch to specific branch worktree
+gh worktree switch feature-auth
+
+# Switch to main worktree
+gh worktree switch main
+
+# Shell mode (outputs path only)
+gh worktree switch --shell
+```
+
 ## Directory Structure
 
 The extension creates worktrees in the parent directory of your current repository:
@@ -98,7 +165,8 @@ parent-directory/
 ├── my-repo/                    # Original repository
 ├── my-repo-pr1234/            # PR #1234 worktree
 ├── my-repo-pr5678/            # PR #5678 worktree
-└── my-repo-pr9999/            # PR #9999 worktree
+├── my-repo-feature-auth/      # Branch worktree for local development
+└── my-repo-experiment-api/    # Branch worktree for local development
 ```
 
 ## Shell Integration
@@ -106,14 +174,14 @@ parent-directory/
 For the best experience, add these shell functions to your `~/.bashrc` or `~/.zshrc`:
 
 ```bash
-# Quick worktree switcher
-ghws() { 
-  local target=$(gh worktree pr switch --shell "$@")
+# Unified worktree switcher (recommended - switches between all worktrees)
+ghws() {
+  local target=$(gh worktree switch --shell "$@")
   [ -n "$target" ] && cd "$target"
 }
 
-# Checkout and cd into new worktree
-ghwc() { 
+# Checkout and cd into new worktree (PR or branch)
+ghwc() {
   local target=$(gh worktree pr checkout --shell "$@")
   [ -n "$target" ] && cd "$target"
 }
@@ -121,24 +189,34 @@ ghwc() {
 
 **Usage:**
 ```bash
-# Interactive selection and switch
+# Interactive selection and switch (all worktrees)
 ghws
 
 # Switch to specific PR
 ghws 1234
+
+# Switch to specific branch worktree
+ghws feature-auth
 
 # Interactive checkout and cd
 ghwc
 
 # Checkout specific PR and cd
 ghwc 1234
+
+# Create branch worktree and cd
+ghwc --create feature-auth
 ```
 
 ## How It Works
 
-1. **Worktree Creation**: Creates git worktrees in `../repo-name-pr{number}` format
+1. **Worktree Creation**: Creates git worktrees in separate directories
+   - PR worktrees: `../repo-name-pr{number}`
+   - Branch worktrees: `../repo-name-{branch-name}`
 2. **Branch Management**: Sets up proper remote tracking and handles cross-repository PRs similar to `gh pr checkout`
-3. **Clean Removal**: Removes both worktree and branch when cleaning up
+3. **Metadata Storage**: Uses git config to track worktree types (`pr` or `branch`)
+4. **Promotion**: Converts branch worktrees to PR worktrees after PR creation
+5. **Clean Removal**: Removes both worktree and branch when cleaning up
 
 ## Comparison with `gh pr checkout`
 
@@ -150,19 +228,44 @@ ghwc 1234
 
 ## Advanced Usage
 
-### Working with Multiple PRs
+### Local Development Workflow
+
+```bash
+# 1. Create a branch worktree for local development
+gh worktree pr checkout --create feature-auth
+
+# 2. Work on your feature...
+cd ../my-repo-feature-auth
+# ... make changes, commit ...
+
+# 3. Create a pull request
+gh pr create
+
+# 4. Promote the branch worktree to PR worktree (auto-detects current branch)
+gh worktree pr promote
+
+# 5. Now it appears in PR worktree list
+gh worktree pr list
+```
+
+### Working with Multiple Worktrees
 
 ```bash
 # Checkout multiple PRs for parallel development
 gh worktree pr checkout 1234
 gh worktree pr checkout 5678
 
+# Create branch worktrees for new features
+gh worktree pr checkout --create feature-auth
+gh worktree pr checkout --create experiment-api
+
 # List all active worktrees
-gh worktree pr list
+gh worktree pr list --all
 
 # Switch between them quickly
-ghws 1234  # Switch to PR 1234
-ghws 5678  # Switch to PR 5678
+ghws 1234           # Switch to PR 1234
+ghws feature-auth   # Switch to branch worktree
+ghws main           # Switch to main worktree
 ```
 
 ### Cross-Repository PRs

--- a/internal/worktree/promote.go
+++ b/internal/worktree/promote.go
@@ -1,0 +1,65 @@
+package worktree
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+
+	"github.com/knqyf263/gh-worktree/internal/git"
+)
+
+// PromoteToPR promotes a branch worktree to a PR worktree by updating its metadata.
+func PromoteToPR(branchName string, prNumber int, prTitle string) error {
+	// Get git root for config path
+	gitRoot, err := git.GetRoot()
+	if err != nil {
+		return fmt.Errorf("failed to get git root: %w", err)
+	}
+
+	// Set worktree type to "pr"
+	if err := git.SetConfig(gitRoot, fmt.Sprintf("branch.%s.gh-worktree-type", branchName), "pr"); err != nil {
+		return fmt.Errorf("failed to set worktree type: %w", err)
+	}
+
+	// Set PR number
+	if err := git.SetConfig(gitRoot, fmt.Sprintf("branch.%s.gh-worktree-pr-number", branchName), strconv.Itoa(prNumber)); err != nil {
+		return fmt.Errorf("failed to set PR number: %w", err)
+	}
+
+	// Set PR title
+	if err := git.SetConfig(gitRoot, fmt.Sprintf("branch.%s.gh-worktree-pr-title", branchName), prTitle); err != nil {
+		return fmt.Errorf("failed to set PR title: %w", err)
+	}
+
+	return nil
+}
+
+// GetWorktreeType returns the type of the worktree for the given branch.
+// Returns "pr", "branch", or "" if not set.
+func GetWorktreeType(branchName string) (string, error) {
+	gitRoot, err := git.GetRoot()
+	if err != nil {
+		return "", fmt.Errorf("failed to get git root: %w", err)
+	}
+
+	worktreeType, err := git.GetConfig(gitRoot, fmt.Sprintf("branch.%s.gh-worktree-type", branchName))
+	if err != nil {
+		// If config doesn't exist, try to detect from PR number
+		prNumber, err := git.GetConfig(gitRoot, fmt.Sprintf("branch.%s.gh-worktree-pr-number", branchName))
+		if err == nil && prNumber != "" {
+			return "pr", nil
+		}
+		return "", nil
+	}
+	return strings.TrimSpace(worktreeType), nil
+}
+
+// SetWorktreeType sets the worktree type metadata for a branch.
+func SetWorktreeType(branchName string, worktreeType string) error {
+	gitRoot, err := git.GetRoot()
+	if err != nil {
+		return fmt.Errorf("failed to get git root: %w", err)
+	}
+
+	return git.SetConfig(gitRoot, fmt.Sprintf("branch.%s.gh-worktree-type", branchName), worktreeType)
+}

--- a/internal/worktree/worktree.go
+++ b/internal/worktree/worktree.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"strconv"
 	"strings"
 
 	"github.com/knqyf263/gh-worktree/internal/git"
@@ -86,32 +87,153 @@ func ListPRWorktrees(repoName string) ([]*Info, error) {
 		return nil, fmt.Errorf("failed to get git root: %w", err)
 	}
 
+	// Resolve symlinks in parent directory for comparison
 	parentDir := filepath.Dir(gitRoot)
+	parentDir, err = filepath.EvalSymlinks(parentDir)
+	if err != nil {
+		// If EvalSymlinks fails, use the original path
+		parentDir = filepath.Dir(gitRoot)
+	}
 
 	var prWorktrees []*Info
 	for _, wt := range allWorktrees {
-		// Check if this is a PR worktree based on naming pattern
-		if strings.HasPrefix(filepath.Base(wt.Path), repoName+"-pr") {
-			// Extract PR number from path
-			baseName := filepath.Base(wt.Path)
+		// Skip main worktree
+		if wt.Path == gitRoot {
+			continue
+		}
+
+		// Resolve symlinks in worktree path for comparison
+		wtParentDir := filepath.Dir(wt.Path)
+		wtParentDir, err = filepath.EvalSymlinks(wtParentDir)
+		if err != nil {
+			// If EvalSymlinks fails, use the original path
+			wtParentDir = filepath.Dir(wt.Path)
+		}
+
+		// Skip if not in parent directory
+		if wtParentDir != parentDir {
+			continue
+		}
+
+		baseName := filepath.Base(wt.Path)
+
+		// Check if this is a PR worktree based on naming pattern (repo-pr###)
+		isPRByName := false
+		if strings.HasPrefix(baseName, repoName+"-pr") {
 			prPrefix := repoName + "-pr"
 			if len(baseName) > len(prPrefix) {
 				prNumberStr := baseName[len(prPrefix):]
 				var prNumber int
 				if n, err := fmt.Sscanf(prNumberStr, "%d", &prNumber); err == nil && n == 1 {
 					wt.PRNumber = prNumber
-					// Verify it's in the expected parent directory
-					if filepath.Dir(wt.Path) == parentDir {
-						// Try to get PR title from git config
-						wt.Title = GetPRTitle(wt.Path, wt.Branch)
-						prWorktrees = append(prWorktrees, wt)
+					isPRByName = true
+				}
+			}
+		}
+
+		// Also check metadata for worktree type
+		worktreeType, _ := GetWorktreeType(wt.Branch)
+		isPRByMetadata := worktreeType == "pr"
+
+		// Include if it's a PR worktree by either naming or metadata
+		if isPRByName || isPRByMetadata {
+			// Get PR title from git config
+			wt.Title = GetPRTitle(wt.Path, wt.Branch)
+			
+			// If PR number not set yet, try to get it from git config
+			if wt.PRNumber == 0 {
+				prNumberStr, err := git.GetConfig(gitRoot, fmt.Sprintf("branch.%s.gh-worktree-pr-number", wt.Branch))
+				if err == nil && prNumberStr != "" {
+					if prNum, err := strconv.Atoi(strings.TrimSpace(prNumberStr)); err == nil {
+						wt.PRNumber = prNum
 					}
 				}
 			}
+			
+			prWorktrees = append(prWorktrees, wt)
 		}
 	}
 
 	return prWorktrees, nil
+}
+
+// ListBranchWorktrees lists all branch worktrees (non-PR worktrees).
+func ListBranchWorktrees(repoName string) ([]*Info, error) {
+	allWorktrees, err := List()
+	if err != nil {
+		return nil, err
+	}
+
+	gitRoot, err := git.GetRoot()
+	if err != nil {
+		return nil, fmt.Errorf("failed to get git root: %w", err)
+	}
+
+	// Resolve symlinks in parent directory for comparison
+	parentDir := filepath.Dir(gitRoot)
+	parentDir, err = filepath.EvalSymlinks(parentDir)
+	if err != nil {
+		// If EvalSymlinks fails, use the original path
+		parentDir = filepath.Dir(gitRoot)
+	}
+
+	var branchWorktrees []*Info
+	for _, wt := range allWorktrees {
+		// Skip main worktree
+		if wt.Path == gitRoot {
+			continue
+		}
+
+		baseName := filepath.Base(wt.Path)
+		
+		// Check if it's NOT a PR worktree (doesn't match repo-pr### pattern)
+		if strings.HasPrefix(baseName, repoName+"-pr") {
+			// Check if it's actually a PR worktree
+			prPrefix := repoName + "-pr"
+			if len(baseName) > len(prPrefix) {
+				prNumberStr := baseName[len(prPrefix):]
+				var prNumber int
+				if n, err := fmt.Sscanf(prNumberStr, "%d", &prNumber); err == nil && n == 1 {
+					// This is a PR worktree, skip it
+					continue
+				}
+			}
+		}
+
+		// Resolve symlinks in worktree path for comparison
+		wtParentDir := filepath.Dir(wt.Path)
+		wtParentDir, err = filepath.EvalSymlinks(wtParentDir)
+		if err != nil {
+			// If EvalSymlinks fails, use the original path
+			wtParentDir = filepath.Dir(wt.Path)
+		}
+
+		// Check if it starts with repo name and is in parent directory
+		if strings.HasPrefix(baseName, repoName+"-") && wtParentDir == parentDir {
+			// Check worktree type from git config
+			worktreeType, _ := GetWorktreeType(wt.Branch)
+			if worktreeType == "branch" || worktreeType == "" {
+				branchWorktrees = append(branchWorktrees, wt)
+			}
+		}
+	}
+
+	return branchWorktrees, nil
+}
+
+// ListAllWorktrees lists all worktrees (PR and branch worktrees).
+func ListAllWorktrees(repoName string) (prWorktrees []*Info, branchWorktrees []*Info, err error) {
+	prWorktrees, err = ListPRWorktrees(repoName)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	branchWorktrees, err = ListBranchWorktrees(repoName)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	return prWorktrees, branchWorktrees, nil
 }
 
 // GetPRTitle retrieves the PR title from git config
@@ -155,4 +277,38 @@ func GeneratePath(repoName string, prNumber int) (string, error) {
 	}
 
 	return filepath.Join(filepath.Dir(gitRoot), fmt.Sprintf("%s-pr%d", repoName, prNumber)), nil
+}
+
+// GeneratePathForBranch generates the path for a branch worktree.
+// Format: ../repo-name-{branch-name}
+func GeneratePathForBranch(repoName string, branchName string) (string, error) {
+	gitRoot, err := git.GetRoot()
+	if err != nil {
+		return "", fmt.Errorf("failed to get git root: %w", err)
+	}
+
+	return filepath.Join(filepath.Dir(gitRoot), fmt.Sprintf("%s-%s", repoName, branchName)), nil
+}
+
+// DetectWorktreeType detects the type of worktree based on its path.
+// Returns "pr", "branch", or "main".
+func DetectWorktreeType(path string) string {
+	// Check if it's the main worktree by looking at git config
+	gitRoot, err := git.GetRoot()
+	if err == nil && path == gitRoot {
+		return "main"
+	}
+
+	// Extract the last component of the path
+	baseName := filepath.Base(path)
+	
+	// Check if it matches PR pattern: repo-pr123
+	if strings.Contains(baseName, "-pr") && len(strings.Split(baseName, "-pr")) == 2 {
+		prPart := strings.Split(baseName, "-pr")[1]
+		if _, err := strconv.Atoi(prPart); err == nil {
+			return "pr"
+		}
+	}
+	
+	return "branch"
 }

--- a/main.go
+++ b/main.go
@@ -38,11 +38,15 @@ func main() {
   # Check out a specific PR in a new worktree
   $ gh worktree pr checkout 32
 
-  # Check out PR from URL in a new worktree  
+  # Check out PR from URL in a new worktree
   $ gh worktree pr checkout https://github.com/OWNER/REPO/pull/32
-  
+
+  # Create a new branch worktree for local development
+  $ gh worktree pr checkout --create feature-auth
+  $ gh worktree pr checkout -c feature-auth
+
   # Use as shell function to checkout and cd (add to ~/.bashrc or ~/.zshrc):
-  $ ghwc() { 
+  $ ghwc() {
       local target=$(gh worktree pr checkout --shell "$@")
       [ -n "$target" ] && cd "$target"
     }
@@ -51,12 +55,19 @@ func main() {
 		Args: cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			shellModeFlag, _ := cmd.Flags().GetBool("shell")
+			createBranch, _ := cmd.Flags().GetString("create")
 			opts.ShellMode = shellModeFlag
 			shellMode = shellModeFlag // Set the outer shellMode variable
 			if shellModeFlag {
 				cmd.SilenceUsage = true
 				cmd.SilenceErrors = true
 			}
+
+			// Handle --create flag for branch worktrees
+			if createBranch != "" {
+				return checkoutBranchWorktree(createBranch, &opts)
+			}
+
 			if len(args) > 0 {
 				return checkoutRun(&opts, args[0])
 			}
@@ -69,6 +80,7 @@ func main() {
 	checkoutCmd.Flags().BoolVarP(&opts.Detach, "detach", "", false, "Checkout PR with a detached HEAD")
 	checkoutCmd.Flags().StringVarP(&opts.BranchName, "branch", "b", "", "Local branch name to use (default [the name of the head branch])")
 	checkoutCmd.Flags().BoolP("shell", "s", false, "Output path only for use in shell functions")
+	checkoutCmd.Flags().StringP("create", "c", "", "Create a new branch worktree for local development")
 
 	var removeOpts struct {
 		Force bool
@@ -99,16 +111,25 @@ func main() {
 
 	removeCmd.Flags().BoolVarP(&removeOpts.Force, "force", "f", false, "Force removal without confirmation")
 
+	var listOpts struct {
+		All bool
+	}
+
 	listCmd := &cobra.Command{
 		Use:   "list",
 		Short: "List pull request worktrees",
 		Example: `  # List all PR worktrees
-  $ gh worktree pr list`,
+  $ gh worktree pr list
+
+  # List all worktrees (PR and branch)
+  $ gh worktree pr list --all`,
 		Args: cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return listRun()
+			return listRun(listOpts.All)
 		},
 	}
+
+	listCmd.Flags().BoolVarP(&listOpts.All, "all", "a", false, "List all worktrees (PR and branch)")
 
 	switchCmd := &cobra.Command{
 		Use:   "switch [<number> | main]",
@@ -148,11 +169,89 @@ func main() {
 
 	switchCmd.Flags().BoolP("shell", "s", false, "Output path only for use in shell functions")
 
+	promoteCmd := &cobra.Command{
+		Use:   "promote [<branch>] [<pr-number>]",
+		Short: "Promote a branch worktree to a PR worktree",
+		Example: `  # Promote current branch worktree after creating a PR
+  $ gh worktree pr promote
+
+  # Promote a specific branch worktree
+  $ gh worktree pr promote feature-auth
+
+  # Promote with explicit PR number
+  $ gh worktree pr promote feature-auth 1234`,
+		Args: cobra.RangeArgs(0, 2),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			var branchName string
+			prNumber := 0
+
+			if len(args) == 0 {
+				// Get current branch name
+				currentBranch := git.GetBranchName(".")
+				if currentBranch == "" || currentBranch == "HEAD" {
+					return fmt.Errorf("could not determine current branch. Please specify branch name")
+				}
+				branchName = currentBranch
+			} else {
+				branchName = args[0]
+				if len(args) > 1 {
+					// Parse PR number if provided
+					var err error
+					prNumber, err = github.ParsePRNumber(args[1])
+					if err != nil {
+						return fmt.Errorf("invalid PR number: %w", err)
+					}
+				}
+			}
+			return promoteRun(branchName, prNumber)
+		},
+	}
+
 	prCmd.AddCommand(checkoutCmd)
 	prCmd.AddCommand(removeCmd)
 	prCmd.AddCommand(listCmd)
 	prCmd.AddCommand(switchCmd)
+	prCmd.AddCommand(promoteCmd)
 	rootCmd.AddCommand(prCmd)
+
+	// Root-level switch command (unified switcher)
+	rootSwitchCmd := &cobra.Command{
+		Use:   "switch [<identifier> | main]",
+		Short: "Switch to any worktree (PR, branch, or main)",
+		Example: `  # Interactively select from all worktrees
+  $ gh worktree switch
+
+  # Switch to specific PR worktree
+  $ gh worktree switch 9060
+
+  # Switch to specific branch worktree
+  $ gh worktree switch feature-auth
+
+  # Switch to main worktree
+  $ gh worktree switch main
+
+  # Use as shell function (add to ~/.bashrc or ~/.zshrc):
+  $ ghws() {
+      local target=$(gh worktree switch --shell "$@")
+      [ -n "$target" ] && cd "$target"
+    }`,
+		Args: cobra.MaximumNArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			shellModeFlag, _ := cmd.Flags().GetBool("shell")
+			shellMode = shellModeFlag
+			if shellModeFlag {
+				cmd.SilenceUsage = true
+				cmd.SilenceErrors = true
+			}
+			identifier := ""
+			if len(args) > 0 {
+				identifier = args[0]
+			}
+			return switchAllRun(shellModeFlag, identifier)
+		},
+	}
+	rootSwitchCmd.Flags().BoolP("shell", "s", false, "Output path only for use in shell functions")
+	rootCmd.AddCommand(rootSwitchCmd)
 
 	if err := rootCmd.Execute(); err != nil {
 		if !shellMode {
@@ -292,6 +391,90 @@ func checkoutRunInteractive(opts *worktree.CheckoutOptions) error {
 	return nil
 }
 
+// checkoutBranchWorktree creates a new worktree for local development.
+func checkoutBranchWorktree(branchName string, opts *worktree.CheckoutOptions) error {
+	// Validate branch name
+	if err := validate.BranchName(branchName); err != nil {
+		return fmt.Errorf("invalid branch name: %w", err)
+	}
+
+	// Get git root and repo name
+	gitRoot, err := git.GetRoot()
+	if err != nil {
+		return fmt.Errorf("failed to get git root: %w", err)
+	}
+
+	repoName := filepath.Base(gitRoot)
+	if err := validate.RepoName(repoName); err != nil {
+		return fmt.Errorf("invalid repository name: %w", err)
+	}
+
+	// Generate worktree path for branch
+	worktreePath, err := worktree.GeneratePathForBranch(repoName, branchName)
+	if err != nil {
+		return fmt.Errorf("failed to generate worktree path: %w", err)
+	}
+
+	// Check if worktree already exists
+	if _, err := os.Stat(worktreePath); err == nil {
+		if opts.ShellMode {
+			// In shell mode, output the existing path so cd still works
+			cwd, err := os.Getwd()
+			if err != nil {
+				return fmt.Errorf("failed to get current directory: %w", err)
+			}
+			relPath, err := filepath.Rel(cwd, worktreePath)
+			if err != nil {
+				relPath = worktreePath
+			}
+			fmt.Print(relPath)
+			return nil
+		}
+		return fmt.Errorf("worktree for branch %s already exists at %s", branchName, worktreePath)
+	}
+
+	// Check if branch already exists
+	branchExists := git.BranchExists(branchName)
+
+	// Create worktree with new branch from HEAD
+	var cmd [][]string
+	if branchExists {
+		// Branch exists, checkout existing branch
+		cmd = [][]string{{"worktree", "add", worktreePath, branchName}}
+	} else {
+		// Create new branch from HEAD
+		cmd = [][]string{{"worktree", "add", "-b", branchName, worktreePath}}
+	}
+
+	if err := git.ExecuteCommands(cmd); err != nil {
+		return fmt.Errorf("failed to create worktree: %w", err)
+	}
+
+	// Set worktree type metadata
+	if err := worktree.SetWorktreeType(branchName, "branch"); err != nil {
+		return fmt.Errorf("failed to set worktree type: %w", err)
+	}
+
+	// Output based on mode
+	if opts.ShellMode {
+		// Shell mode: output only the path for use in shell functions
+		cwd, err := os.Getwd()
+		if err != nil {
+			return fmt.Errorf("failed to get current directory: %w", err)
+		}
+
+		relPath, err := filepath.Rel(cwd, worktreePath)
+		if err != nil {
+			relPath = worktreePath
+		}
+		fmt.Print(relPath)
+	} else {
+		// Normal mode: output a friendly message
+		fmt.Printf("Created worktree for branch '%s' at %s\n", branchName, worktreePath)
+	}
+	return nil
+}
+
 func checkoutRun(opts *worktree.CheckoutOptions, selector string) error {
 	// Get current repository
 	repo, err := repository.Current()
@@ -391,13 +574,6 @@ func checkoutRun(opts *worktree.CheckoutOptions, selector string) error {
 }
 
 func removeRun(selector string, force bool) error {
-	// Parse PR number from selector
-	prNumber, err := github.ParsePRNumber(selector)
-	if err != nil {
-		return fmt.Errorf("failed to parse PR number: %w", err)
-	}
-
-	// Generate worktree path
 	gitRoot, err := git.GetRoot()
 	if err != nil {
 		return fmt.Errorf("failed to get git root: %w", err)
@@ -407,27 +583,56 @@ func removeRun(selector string, force bool) error {
 	if err := validate.RepoName(repoName); err != nil {
 		return fmt.Errorf("invalid repository name: %w", err)
 	}
-	if err := validate.PRNumber(prNumber); err != nil {
-		return fmt.Errorf("invalid PR number: %w", err)
-	}
 
-	worktreePath, err := worktree.GeneratePath(repoName, prNumber)
-	if err != nil {
-		return fmt.Errorf("failed to generate worktree path: %w", err)
+	var worktreePath string
+	var prNumber int
+	var isBranchWorktree bool
+
+	// Try to parse as PR number
+	prNum, err := github.ParsePRNumber(selector)
+	if err == nil {
+		// It's a PR number
+		if err := validate.PRNumber(prNum); err != nil {
+			return fmt.Errorf("invalid PR number: %w", err)
+		}
+		prNumber = prNum
+
+		worktreePath, err = worktree.GeneratePath(repoName, prNumber)
+		if err != nil {
+			return fmt.Errorf("failed to generate worktree path: %w", err)
+		}
+	} else {
+		// Try as branch name
+		if err := validate.BranchName(selector); err != nil {
+			return fmt.Errorf("invalid identifier: not a valid PR number or branch name: %w", err)
+		}
+
+		worktreePath, err = worktree.GeneratePathForBranch(repoName, selector)
+		if err != nil {
+			return fmt.Errorf("failed to generate worktree path: %w", err)
+		}
+		isBranchWorktree = true
 	}
 
 	// Check if worktree exists
 	if _, err := os.Stat(worktreePath); os.IsNotExist(err) {
+		if isBranchWorktree {
+			return fmt.Errorf("worktree for branch %s does not exist at %s", selector, worktreePath)
+		}
 		return fmt.Errorf("worktree for PR #%d does not exist at %s", prNumber, worktreePath)
 	}
 
 	// Get branch name before removing worktree
 	branchName := git.GetBranchName(worktreePath)
 
-	// Get PR title from git config before removing
+	// Get title/metadata from git config before removing
 	title := ""
 	if branchName != "" {
-		title = worktree.GetPRTitle(worktreePath, branchName)
+		if isBranchWorktree {
+			title = "(local development)"
+		} else {
+			title = worktree.GetPRTitle(worktreePath, branchName)
+		}
 	}
 
 	// Remove the worktree
@@ -449,29 +654,26 @@ func removeRun(selector string, force bool) error {
 		}
 	}
 
-	fmt.Printf("Removed worktree for #%d at %s\n", prNumber, worktreePath)
-	if title != "" {
-		fmt.Printf("Title: %s\n", title)
+	// Output based on worktree type
+	if isBranchWorktree {
+		fmt.Printf("Removed worktree for branch '%s' at %s\n", selector, worktreePath)
+	} else {
+		fmt.Printf("Removed worktree for #%d at %s\n", prNumber, worktreePath)
+		if title != "" {
+			fmt.Printf("Title: %s\n", title)
+		}
 	}
+
 	return nil
 }
 
-func listRun() error {
+func listRun(showAll bool) error {
 	gitRoot, err := git.GetRoot()
 	if err != nil {
 		return fmt.Errorf("failed to get git root: %w", err)
 	}
 
 	repoName := filepath.Base(gitRoot)
-	prWorktrees, err := worktree.ListPRWorktrees(repoName)
-	if err != nil {
-		return fmt.Errorf("failed to get PR worktrees: %w", err)
-	}
-
-	if len(prWorktrees) == 0 {
-		fmt.Println("No PR worktrees found.")
-		return nil
-	}
 
 	// Get current working directory for relative path calculation
 	cwd, err := os.Getwd()
@@ -479,20 +681,77 @@ func listRun() error {
 		return fmt.Errorf("failed to get current directory: %w", err)
 	}
 
-	fmt.Printf("PR worktrees:\n")
-	for _, wt := range prWorktrees {
-		title := wt.Title
-		if title == "" {
-			title = "(no title)"
-		}
-
-		// Convert absolute path to relative path
-		relPath, err := filepath.Rel(cwd, wt.Path)
+	if showAll {
+		// List both PR and branch worktrees
+		prWorktrees, branchWorktrees, err := worktree.ListAllWorktrees(repoName)
 		if err != nil {
-			relPath = wt.Path // Fall back to absolute path if relative path fails
+			return fmt.Errorf("failed to get worktrees: %w", err)
 		}
 
-		fmt.Printf("  #%d\t%s\t%s\t%s\n", wt.PRNumber, wt.Branch, title, relPath)
+		if len(prWorktrees) == 0 && len(branchWorktrees) == 0 {
+			fmt.Println("No worktrees found.")
+			return nil
+		}
+
+		// List PR worktrees
+		if len(prWorktrees) > 0 {
+			fmt.Printf("PR worktrees:\n")
+			for _, wt := range prWorktrees {
+				title := wt.Title
+				if title == "" {
+					title = "(no title)"
+				}
+
+				relPath, err := filepath.Rel(cwd, wt.Path)
+				if err != nil {
+					relPath = wt.Path
+				}
+
+				fmt.Printf("  #%d\t%s\t%s\t%s\n", wt.PRNumber, wt.Branch, title, relPath)
+			}
+		}
+
+		// List branch worktrees
+		if len(branchWorktrees) > 0 {
+			if len(prWorktrees) > 0 {
+				fmt.Println()
+			}
+			fmt.Printf("Branch worktrees:\n")
+			for _, wt := range branchWorktrees {
+				relPath, err := filepath.Rel(cwd, wt.Path)
+				if err != nil {
+					relPath = wt.Path
+				}
+
+				fmt.Printf("  %s\t(local development)\t%s\n", wt.Branch, relPath)
+			}
+		}
+	} else {
+		// List only PR worktrees (default behavior)
+		prWorktrees, err := worktree.ListPRWorktrees(repoName)
+		if err != nil {
+			return fmt.Errorf("failed to get PR worktrees: %w", err)
+		}
+
+		if len(prWorktrees) == 0 {
+			fmt.Println("No PR worktrees found.")
+			return nil
+		}
+
+		fmt.Printf("PR worktrees:\n")
+		for _, wt := range prWorktrees {
+			title := wt.Title
+			if title == "" {
+				title = "(no title)"
+			}
+
+			relPath, err := filepath.Rel(cwd, wt.Path)
+			if err != nil {
+				relPath = wt.Path
+			}
+
+			fmt.Printf("  #%d\t%s\t%s\t%s\n", wt.PRNumber, wt.Branch, title, relPath)
+		}
 	}
 
 	return nil
@@ -617,6 +876,214 @@ func switchRun(shellMode bool, prNumber string) error {
 	return nil
 }
 
+// promoteRun promotes a branch worktree to a PR worktree.
+func promoteRun(branchName string, prNumber int) error {
+	// Validate branch name
+	if err := validate.BranchName(branchName); err != nil {
+		return fmt.Errorf("invalid branch name: %w", err)
+	}
+
+	// Check if it's already a PR worktree
+	worktreeType, err := worktree.GetWorktreeType(branchName)
+	if err != nil {
+		return fmt.Errorf("failed to get worktree type: %w", err)
+	}
+	if worktreeType == "pr" {
+		return fmt.Errorf("branch %s is already a PR worktree", branchName)
+	}
+
+	// If PR number not provided, try to find it from the branch
+	if prNumber == 0 {
+		// Get current repository
+		repo, err := repository.Current()
+		if err != nil {
+			return fmt.Errorf("failed to get current repository: %w", err)
+		}
+
+		// Get all PRs for this branch
+		client, err := api.DefaultRESTClient()
+		if err != nil {
+			return fmt.Errorf("failed to create REST client: %w", err)
+		}
+
+		var prs []github.PullRequest
+		err = client.Get(fmt.Sprintf("repos/%s/%s/pulls?head=%s:%s&state=open", 
+			repo.Owner, repo.Name, repo.Owner, branchName), &prs)
+		if err != nil {
+			return fmt.Errorf("failed to get PRs for branch: %w", err)
+		}
+
+		if len(prs) == 0 {
+			return fmt.Errorf("no open PR found for branch %s. Please create a PR first or specify the PR number", branchName)
+		}
+
+		if len(prs) > 1 {
+			return fmt.Errorf("multiple PRs found for branch %s. Please specify the PR number", branchName)
+		}
+
+		prNumber = prs[0].Number
+	}
+
+	// Get PR details to get the title
+	repo, err := repository.Current()
+	if err != nil {
+		return fmt.Errorf("failed to get current repository: %w", err)
+	}
+
+	client, err := api.DefaultRESTClient()
+	if err != nil {
+		return fmt.Errorf("failed to create REST client: %w", err)
+	}
+
+	var pr github.PullRequest
+	err = client.Get(fmt.Sprintf("repos/%s/%s/pulls/%d", repo.Owner, repo.Name, prNumber), &pr)
+	if err != nil {
+		return fmt.Errorf("failed to get PR details: %w", err)
+	}
+
+	// Promote to PR worktree
+	if err := worktree.PromoteToPR(branchName, prNumber, pr.Title); err != nil {
+		return fmt.Errorf("failed to promote worktree: %w", err)
+	}
+
+	fmt.Printf("Promoted worktree for branch '%s' to PR #%d\n", branchName, prNumber)
+	if pr.Title != "" {
+		fmt.Printf("Title: %s\n", pr.Title)
+	}
+
+	return nil
+}
+
+// switchAllRun switches to any worktree (PR, branch, or main).
+func switchAllRun(shellMode bool, identifier string) error {
+	gitRoot, err := git.GetRoot()
+	if err != nil {
+		return fmt.Errorf("failed to get git root: %w", err)
+	}
+
+	repoName := filepath.Base(gitRoot)
+	prWorktrees, branchWorktrees, err := worktree.ListAllWorktrees(repoName)
+	if err != nil {
+		return fmt.Errorf("failed to get worktrees: %w", err)
+	}
+
+	var targetPath string
+
+	// Handle direct selection
+	if identifier != "" {
+		if identifier == "main" {
+			targetPath = gitRoot
+		} else {
+			// Try to parse as PR number
+			if prNum, err := github.ParsePRNumber(identifier); err == nil {
+				for _, wt := range prWorktrees {
+					if wt.PRNumber == prNum {
+						targetPath = wt.Path
+						break
+					}
+				}
+			}
+
+			// If not found as PR, try to find as branch name
+			if targetPath == "" {
+				for _, wt := range branchWorktrees {
+					if wt.Branch == identifier {
+						targetPath = wt.Path
+						break
+					}
+				}
+			}
+
+			if targetPath == "" {
+				if !shellMode {
+					fmt.Printf("Worktree '%s' not found.\n", identifier)
+				}
+				return nil
+			}
+		}
+	} else {
+		// Interactive selection
+		candidates := []string{}
+
+		// Add main worktree as first option
+		candidates = append(candidates, "main\tmain\t(main worktree)")
+
+		// Add PR worktrees
+		for _, wt := range prWorktrees {
+			title := wt.Title
+			if title == "" {
+				title = "(no title)"
+			}
+			candidates = append(candidates, fmt.Sprintf("#%d\t%s\t%s",
+				wt.PRNumber,
+				wt.Branch,
+				title))
+		}
+
+		// Add branch worktrees
+		for _, wt := range branchWorktrees {
+			candidates = append(candidates, fmt.Sprintf("branch:%s\t%s\t(local development)",
+				wt.Branch,
+				wt.Branch))
+		}
+
+		// Use gh CLI's built-in selection
+		selection, err := promptSelect("Select a worktree to switch to", candidates)
+		if err != nil {
+			if shellMode {
+				return nil
+			}
+			return err
+		}
+
+		if selection == -1 {
+			if !shellMode {
+				fmt.Println("Cancelled.")
+			}
+			return nil
+		}
+
+		if selection == 0 {
+			// Main worktree selected
+			targetPath = gitRoot
+		} else if selection <= len(prWorktrees) {
+			// PR worktree selected
+			targetPath = prWorktrees[selection-1].Path
+		} else {
+			// Branch worktree selected
+			targetPath = branchWorktrees[selection-1-len(prWorktrees)].Path
+		}
+	}
+
+	// Get current working directory for relative path calculation
+	cwd, err := os.Getwd()
+	if err != nil {
+		return fmt.Errorf("failed to get current directory: %w", err)
+	}
+
+	// Convert absolute path to relative path
+	relPath, err := filepath.Rel(cwd, targetPath)
+	if err != nil {
+		relPath = targetPath
+	}
+
+	// Output based on mode
+	if shellMode {
+		// Shell mode: output only the path
+		fmt.Print(relPath)
+	} else {
+		// Normal mode: output a friendly message
+		if targetPath == gitRoot {
+			fmt.Printf("To switch to main worktree:\n")
+		} else {
+			fmt.Printf("To switch to worktree:\n")
+		}
+		fmt.Printf("cd %s\n", relPath)
+	}
+
+	return nil
+}
+
 func removeRunInteractive(force bool) error {
 	gitRoot, err := git.GetRoot()
 	if err != nil {
@@ -624,23 +1091,36 @@ func removeRunInteractive(force bool) error {
 	}
 
 	repoName := filepath.Base(gitRoot)
-	prWorktrees, err := worktree.ListPRWorktrees(repoName)
+	prWorktrees, branchWorktrees, err := worktree.ListAllWorktrees(repoName)
 	if err != nil {
-		return fmt.Errorf("failed to get PR worktrees: %w", err)
+		return fmt.Errorf("failed to get worktrees: %w", err)
 	}
 
-	if len(prWorktrees) == 0 {
-		fmt.Println("No PR worktrees found.")
+	if len(prWorktrees) == 0 && len(branchWorktrees) == 0 {
+		fmt.Println("No worktrees found.")
 		return nil
 	}
 
-	// Create candidates list in the same format as gh CLI
+	// Create candidates list
 	candidates := []string{}
+	
+	// Add PR worktrees
 	for _, wt := range prWorktrees {
+		title := wt.Title
+		if title == "" {
+			title = "(no title)"
+		}
 		candidates = append(candidates, fmt.Sprintf("#%d\t%s\t%s",
 			wt.PRNumber,
 			wt.Branch,
-			filepath.Base(wt.Path)))
+			title))
+	}
+
+	// Add branch worktrees
+	for _, wt := range branchWorktrees {
+		candidates = append(candidates, fmt.Sprintf("branch:%s\t%s\t(local development)",
+			wt.Branch,
+			wt.Branch))
 	}
 
 	// Use gh CLI's built-in selection
@@ -654,7 +1134,17 @@ func removeRunInteractive(force bool) error {
 		return nil
 	}
 
-	selectedWorktree := prWorktrees[selection]
+	var selectedWorktree *worktree.Info
+	var isBranchWorktree bool
+
+	if selection < len(prWorktrees) {
+		// PR worktree selected
+		selectedWorktree = prWorktrees[selection]
+	} else {
+		// Branch worktree selected
+		selectedWorktree = branchWorktrees[selection-len(prWorktrees)]
+		isBranchWorktree = true
+	}
 
 	// Remove the worktree
 	err = worktree.Remove(selectedWorktree.Path, force)
@@ -675,10 +1165,16 @@ func removeRunInteractive(force bool) error {
 		}
 	}
 
-	fmt.Printf("Removed worktree for #%d at %s\n", selectedWorktree.PRNumber, selectedWorktree.Path)
-	if selectedWorktree.Title != "" {
-		fmt.Printf("Title: %s\n", selectedWorktree.Title)
+	// Output based on worktree type
+	if isBranchWorktree {
+		fmt.Printf("Removed worktree for branch '%s' at %s\n", selectedWorktree.Branch, selectedWorktree.Path)
+	} else {
+		fmt.Printf("Removed worktree for #%d at %s\n", selectedWorktree.PRNumber, selectedWorktree.Path)
+		if selectedWorktree.Title != "" {
+			fmt.Printf("Title: %s\n", selectedWorktree.Title)
+		}
 	}
+
 	return nil
 }
 


### PR DESCRIPTION
## Summary

Adds support for creating worktrees for local development before PR creation, with the ability to promote them to PR worktrees later.

Closes #8

## Changes

### New Features

1. **Branch worktree creation** (`--create/-c` flag)
   - `gh worktree pr checkout --create feature-name`
   - Creates worktree at `../repo-feature-name`
   - Tracked via git config metadata

2. **Promote command** (`gh worktree pr promote`)
   - Auto-detects current branch and PR number
   - Supports explicit branch and PR number arguments
   - Updates metadata without directory renaming

3. **Unified switcher** (`gh worktree switch`)
   - Switch between all worktrees (PR, branch, main)
   - Interactive selection or direct specification
   - Shell mode support with `--shell` flag

4. **List all worktrees** (`--all` flag)
   - `gh worktree pr list --all`
   - Shows both PR and branch worktrees

5. **Remove branch worktrees**
   - Extended existing remove command to support branch worktrees

### Implementation Details

- New file: `internal/worktree/promote.go`
  - `PromoteToPR()`: Promotes branch worktree to PR worktree
  - `GetWorktreeType()`: Retrieves worktree type from metadata
  - `SetWorktreeType()`: Sets worktree type metadata

- Updated: `internal/worktree/worktree.go`
  - `GeneratePathForBranch()`: Generates path for branch worktrees
  - `DetectWorktreeType()`: Detects worktree type (pr/branch/main)
  - `ListBranchWorktrees()`: Lists branch worktrees
  - `ListAllWorktrees()`: Lists all worktrees
  - Enhanced `ListPRWorktrees()` to detect promoted worktrees via metadata

- Updated: `main.go`
  - Added `--create/-c` flag to checkout command
  - Added `promote` subcommand
  - Added unified `switch` command at root level
  - Added `--all` flag to list command
  - Extended remove command for branch worktrees

- Updated: `README.md`
  - Documented all new features
  - Added local development workflow examples
  - Updated shell integration examples

### Bug Fixes

- Fixed symlink resolution for macOS compatibility (`/var` vs `/private/var`)
- Enhanced PR worktree detection to use both naming pattern and metadata

## Test Plan

Tested with `git@github.com:knqyf263/gh-worktree-test.git`:
- ✅ Create branch worktree with `--create` flag
- ✅ Promote branch worktree after PR creation
- ✅ List all worktrees with `--all` flag
- ✅ Switch between different worktree types
- ✅ Remove branch worktrees
- ✅ All unit tests passing
- ✅ Linter passing with no issues