### PR TITLE
refactor: simplify switch command display format

### DIFF
--- a/main.go
+++ b/main.go
@@ -1006,7 +1006,7 @@ func switchAllRun(shellMode bool, identifier string) error {
 		candidates := []string{}
 
 		// Add main worktree as first option
-		candidates = append(candidates, "main\tmain\t(main worktree)")
+		candidates = append(candidates, "main\t(main worktree)")
 
 		// Add PR worktrees
 		for _, wt := range prWorktrees {
@@ -1014,16 +1014,14 @@ func switchAllRun(shellMode bool, identifier string) error {
 			if title == "" {
 				title = "(no title)"
 			}
-			candidates = append(candidates, fmt.Sprintf("#%d\t%s\t%s",
+			candidates = append(candidates, fmt.Sprintf("#%d\t%s",
 				wt.PRNumber,
-				wt.Branch,
 				title))
 		}
 
 		// Add branch worktrees
 		for _, wt := range branchWorktrees {
-			candidates = append(candidates, fmt.Sprintf("branch:%s\t%s\t(local development)",
-				wt.Branch,
+			candidates = append(candidates, fmt.Sprintf("%s\t(local development)",
 				wt.Branch))
 		}
 


### PR DESCRIPTION
## Summary
- Improved the display format for the switch command to be more concise and readable
- Unified all worktrees to a consistent 2-column format

## Changes
- **Main worktree**: `main` + `(main worktree)`
- **PR worktree**: `#1` + PR title (removed redundant branch name)
- **Branch worktree**: branch name + `(local development)` (removed `branch:` prefix and duplicate)

## Before
```
main	main	(main worktree)
#1	copilot/hello-world-golang	Add hello world example in Golang
branch:test-branch-1	test-branch-1	(local development)
```

## After
```
main	(main worktree)
#1	Add hello world example in Golang
test-branch-1	(local development)
```

## Test Plan
- [x] Run all tests: `go test -v ./...`
- [x] Run linter: `golangci-lint run`
- [x] Manual testing with test repository confirmed the improved display format