### PR TITLE
feat: add post-creation setup for worktrees

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ Instead of checking out pull requests in your current directory, this extension 
 - 🗑️ **Clean removal** - Remove worktrees and associated branches in one command
 - 📋 **List all worktrees** - See all your PR and branch worktrees at a glance
 - 🎯 **Interactive selection** - Use arrow keys and filtering to select from all worktrees
+- ⚙️ **Post-creation setup** - Automatically copy files and run commands in new worktrees
 
 ## Installation
 
@@ -281,6 +282,74 @@ The extension will:
 - Set up appropriate remotes
 - Configure push/pull settings
 - Handle `maintainer_can_modify` permissions
+
+## Post-Creation Setup
+
+Automatically run commands when creating new worktrees, such as copying configuration files or installing dependencies.
+
+### Configuration
+
+Create a `.gh-worktree.yml` file in your repository root:
+
+```yaml
+setup:
+  run:
+    - cp -r "$GH_WORKTREE_MAIN_DIR/.claude" .
+    - cp "$GH_WORKTREE_MAIN_DIR/.env.local" . || true
+    - pnpm install
+```
+
+### How It Works
+
+- Commands run automatically after creating any worktree (PR or branch)
+- Commands execute in the new worktree directory
+- `GH_WORKTREE_MAIN_DIR` environment variable points to the main worktree
+- Setup continues even if commands fail (shows warnings)
+- Works correctly when creating worktrees from other worktrees
+
+### Skipping Setup
+
+Skip post-creation setup with the `--no-setup` flag:
+
+```bash
+gh worktree pr checkout 1234 --no-setup
+gh worktree pr checkout --create feature-auth --no-setup
+```
+
+### Common Use Cases
+
+**Copy configuration files:**
+```yaml
+setup:
+  run:
+    - cp "$GH_WORKTREE_MAIN_DIR/.env.local" .
+    - cp -r "$GH_WORKTREE_MAIN_DIR/.vscode" .
+```
+
+**Install dependencies:**
+```yaml
+setup:
+  run:
+    - pnpm install
+    - npm run build
+```
+
+**Initialize development environment:**
+```yaml
+setup:
+  run:
+    - cp "$GH_WORKTREE_MAIN_DIR/.env.example" .env
+    - pnpm install
+    - pnpm run db:migrate
+```
+
+**Claude Code setup:**
+```yaml
+setup:
+  run:
+    - cp -r "$GH_WORKTREE_MAIN_DIR/.claude" .
+    - echo "Worktree ready for Claude Code!"
+```
 
 ## Requirements
 

--- a/internal/git/git.go
+++ b/internal/git/git.go
@@ -69,6 +69,25 @@ func GetRoot() (string, error) {
 	return filepath.Dir(absGitDir), nil
 }
 
+// GetMainWorktree returns the path to the main worktree
+func GetMainWorktree() (string, error) {
+	cmd := exec.Command("git", "worktree", "list", "--porcelain")
+	output, err := cmd.Output()
+	if err != nil {
+		return "", fmt.Errorf("failed to list worktrees: %w", err)
+	}
+
+	lines := strings.Split(strings.TrimSpace(string(output)), "\n")
+	for _, line := range lines {
+		if strings.HasPrefix(line, "worktree ") {
+			// The first worktree entry is always the main worktree
+			return strings.TrimPrefix(line, "worktree "), nil
+		}
+	}
+
+	return "", fmt.Errorf("no worktree found")
+}
+
 // BranchExists checks if a local branch exists
 func BranchExists(branchName string) bool {
 	cmd := exec.Command("git", "show-ref", "--verify", "--quiet", fmt.Sprintf("refs/heads/%s", branchName))

--- a/internal/git/git_test.go
+++ b/internal/git/git_test.go
@@ -171,3 +171,29 @@ func TestExecuteCommands(t *testing.T) {
 		})
 	}
 }
+
+func TestGetMainWorktree(t *testing.T) {
+	// Skip if not in a git repository
+	if _, err := os.Stat(".git"); os.IsNotExist(err) {
+		t.Skip("Not in a git repository")
+	}
+
+	mainWorktree, err := GetMainWorktree()
+	if err != nil {
+		t.Fatalf("GetMainWorktree() error = %v", err)
+	}
+
+	if mainWorktree == "" {
+		t.Error("GetMainWorktree() returned empty path")
+	}
+
+	// Verify the returned path exists and is a directory
+	info, err := os.Stat(mainWorktree)
+	if err != nil {
+		t.Errorf("GetMainWorktree() returned path that doesn't exist: %v", err)
+	}
+
+	if !info.IsDir() {
+		t.Error("GetMainWorktree() returned path is not a directory")
+	}
+}

--- a/internal/setup/config.go
+++ b/internal/setup/config.go
@@ -1,0 +1,42 @@
+package setup
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"gopkg.in/yaml.v3"
+)
+
+// Config represents the .gh-worktree.yml configuration
+type Config struct {
+	Setup SetupConfig `yaml:"setup"`
+}
+
+// SetupConfig contains post-creation setup commands
+type SetupConfig struct {
+	Run []string `yaml:"run"`
+}
+
+// LoadConfig loads the .gh-worktree.yml configuration from the main worktree
+func LoadConfig(mainWorktreePath string) (*Config, error) {
+	configPath := filepath.Join(mainWorktreePath, ".gh-worktree.yml")
+
+	// Check if config file exists
+	if _, err := os.Stat(configPath); os.IsNotExist(err) {
+		// No config file is not an error, just return empty config
+		return &Config{}, nil
+	}
+
+	data, err := os.ReadFile(configPath)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read config file: %w", err)
+	}
+
+	var config Config
+	if err := yaml.Unmarshal(data, &config); err != nil {
+		return nil, fmt.Errorf("failed to parse config file: %w", err)
+	}
+
+	return &config, nil
+}

--- a/internal/setup/config_test.go
+++ b/internal/setup/config_test.go
@@ -1,0 +1,106 @@
+package setup
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestLoadConfig(t *testing.T) {
+	tests := []struct {
+		name        string
+		configYAML  string
+		wantErr     bool
+		wantRunLen  int
+		wantFirstCmd string
+	}{
+		{
+			name: "valid config with multiple commands",
+			configYAML: `setup:
+  run:
+    - echo "test1"
+    - echo "test2"
+    - pnpm install`,
+			wantErr:      false,
+			wantRunLen:   3,
+			wantFirstCmd: `echo "test1"`,
+		},
+		{
+			name: "valid config with single command",
+			configYAML: `setup:
+  run:
+    - pnpm install`,
+			wantErr:      false,
+			wantRunLen:   1,
+			wantFirstCmd: "pnpm install",
+		},
+		{
+			name:       "empty config",
+			configYAML: `setup:`,
+			wantErr:    false,
+			wantRunLen: 0,
+		},
+		{
+			name:       "no config file (handled by LoadConfig returning empty)",
+			configYAML: "",
+			wantErr:    false,
+			wantRunLen: 0,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Create a temporary directory
+			tmpDir := t.TempDir()
+
+			if tt.configYAML != "" {
+				// Write the config file
+				configPath := filepath.Join(tmpDir, ".gh-worktree.yml")
+				if err := os.WriteFile(configPath, []byte(tt.configYAML), 0644); err != nil {
+					t.Fatalf("failed to write test config: %v", err)
+				}
+			}
+
+			// Load config
+			config, err := LoadConfig(tmpDir)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("LoadConfig() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+
+			if err != nil {
+				return
+			}
+
+			// Check run commands length
+			if len(config.Setup.Run) != tt.wantRunLen {
+				t.Errorf("LoadConfig() got %d run commands, want %d", len(config.Setup.Run), tt.wantRunLen)
+			}
+
+			// Check first command if expected
+			if tt.wantRunLen > 0 && config.Setup.Run[0] != tt.wantFirstCmd {
+				t.Errorf("LoadConfig() first command = %q, want %q", config.Setup.Run[0], tt.wantFirstCmd)
+			}
+		})
+	}
+}
+
+func TestLoadConfig_InvalidYAML(t *testing.T) {
+	tmpDir := t.TempDir()
+	configPath := filepath.Join(tmpDir, ".gh-worktree.yml")
+
+	// Write invalid YAML
+	invalidYAML := `setup:
+  run:
+    - echo "test
+    invalid yaml`
+	if err := os.WriteFile(configPath, []byte(invalidYAML), 0644); err != nil {
+		t.Fatalf("failed to write test config: %v", err)
+	}
+
+	// Load config should fail
+	_, err := LoadConfig(tmpDir)
+	if err == nil {
+		t.Error("LoadConfig() expected error for invalid YAML, got nil")
+	}
+}

--- a/internal/setup/setup.go
+++ b/internal/setup/setup.go
@@ -1,0 +1,63 @@
+package setup
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+)
+
+// RunSetup executes post-creation setup commands in the new worktree
+func RunSetup(newWorktreePath, mainWorktreePath string) error {
+	config, err := LoadConfig(mainWorktreePath)
+	if err != nil {
+		return fmt.Errorf("failed to load config: %w", err)
+	}
+
+	// If no setup commands are configured, skip
+	if len(config.Setup.Run) == 0 {
+		return nil
+	}
+
+	fmt.Println("→ Running post-creation setup...")
+
+	var warnings []string
+
+	for _, cmdStr := range config.Setup.Run {
+		fmt.Printf("  ✓ %s\n", cmdStr)
+
+		// Execute command in the new worktree directory with GH_WORKTREE_MAIN_DIR env var
+		cmd := exec.Command("sh", "-c", cmdStr)
+		cmd.Dir = newWorktreePath
+		cmd.Env = append(os.Environ(), fmt.Sprintf("GH_WORKTREE_MAIN_DIR=%s", mainWorktreePath))
+		cmd.Stdout = os.Stdout
+		cmd.Stderr = os.Stderr
+
+		if err := cmd.Run(); err != nil {
+			warning := fmt.Sprintf("Command failed (exit %d): %s", cmd.ProcessState.ExitCode(), cmdStr)
+			warnings = append(warnings, warning)
+			fmt.Printf("  ⚠ %s\n", warning)
+		}
+	}
+
+	if len(warnings) > 0 {
+		fmt.Println("  ⚠ Setup completed with warnings")
+	} else {
+		fmt.Println("  ✓ Setup completed")
+	}
+
+	return nil
+}
+
+// ShouldRunSetup checks if setup should be executed
+func ShouldRunSetup(mainWorktreePath string) bool {
+	config, err := LoadConfig(mainWorktreePath)
+	if err != nil {
+		return false
+	}
+	return len(config.Setup.Run) > 0
+}
+
+// PrintSkippedMessage prints a message when setup is skipped
+func PrintSkippedMessage() {
+	fmt.Println("  (setup skipped)")
+}

--- a/internal/setup/setup_test.go
+++ b/internal/setup/setup_test.go
@@ -1,0 +1,123 @@
+package setup
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestShouldRunSetup(t *testing.T) {
+	tests := []struct {
+		name       string
+		configYAML string
+		want       bool
+	}{
+		{
+			name: "config with commands",
+			configYAML: `setup:
+  run:
+    - echo "test"`,
+			want: true,
+		},
+		{
+			name:       "empty config",
+			configYAML: `setup:`,
+			want:       false,
+		},
+		{
+			name:       "no config file",
+			configYAML: "",
+			want:       false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tmpDir := t.TempDir()
+
+			if tt.configYAML != "" {
+				configPath := filepath.Join(tmpDir, ".gh-worktree.yml")
+				if err := os.WriteFile(configPath, []byte(tt.configYAML), 0644); err != nil {
+					t.Fatalf("failed to write test config: %v", err)
+				}
+			}
+
+			got := ShouldRunSetup(tmpDir)
+			if got != tt.want {
+				t.Errorf("ShouldRunSetup() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestRunSetup_NoConfig(t *testing.T) {
+	// Create temporary directories
+	mainDir := t.TempDir()
+	newDir := t.TempDir()
+
+	// Run setup with no config file (should succeed without doing anything)
+	err := RunSetup(newDir, mainDir)
+	if err != nil {
+		t.Errorf("RunSetup() with no config should not error, got: %v", err)
+	}
+}
+
+func TestRunSetup_WithSimpleCommand(t *testing.T) {
+	// Create temporary directories
+	mainDir := t.TempDir()
+	newDir := t.TempDir()
+
+	// Create a simple config that creates a test file
+	configYAML := `setup:
+  run:
+    - touch test-file.txt`
+	configPath := filepath.Join(mainDir, ".gh-worktree.yml")
+	if err := os.WriteFile(configPath, []byte(configYAML), 0644); err != nil {
+		t.Fatalf("failed to write test config: %v", err)
+	}
+
+	// Run setup
+	err := RunSetup(newDir, mainDir)
+	if err != nil {
+		t.Errorf("RunSetup() error = %v", err)
+	}
+
+	// Verify the file was created in the new directory
+	testFile := filepath.Join(newDir, "test-file.txt")
+	if _, err := os.Stat(testFile); os.IsNotExist(err) {
+		t.Errorf("Expected file %s to be created", testFile)
+	}
+}
+
+func TestRunSetup_WithEnvironmentVariable(t *testing.T) {
+	// Create temporary directories
+	mainDir := t.TempDir()
+	newDir := t.TempDir()
+
+	// Create a marker file in main directory
+	markerFile := filepath.Join(mainDir, "main-marker.txt")
+	if err := os.WriteFile(markerFile, []byte("marker"), 0644); err != nil {
+		t.Fatalf("failed to write marker file: %v", err)
+	}
+
+	// Create config that uses GH_WORKTREE_MAIN_DIR
+	configYAML := `setup:
+  run:
+    - cp "$GH_WORKTREE_MAIN_DIR/main-marker.txt" ./copied-marker.txt`
+	configPath := filepath.Join(mainDir, ".gh-worktree.yml")
+	if err := os.WriteFile(configPath, []byte(configYAML), 0644); err != nil {
+		t.Fatalf("failed to write test config: %v", err)
+	}
+
+	// Run setup
+	err := RunSetup(newDir, mainDir)
+	if err != nil {
+		t.Errorf("RunSetup() error = %v", err)
+	}
+
+	// Verify the file was copied to the new directory
+	copiedFile := filepath.Join(newDir, "copied-marker.txt")
+	if _, err := os.Stat(copiedFile); os.IsNotExist(err) {
+		t.Errorf("Expected file %s to be created via environment variable", copiedFile)
+	}
+}


### PR DESCRIPTION
## Summary

Add support for automatically running setup commands when creating new worktrees via `.gh-worktree.yml` configuration file.

## Features

- Execute commands in new worktree directory after creation
- `GH_WORKTREE_MAIN_DIR` environment variable points to main worktree
- Works for both PR and branch worktrees
- Auto-detects main worktree even when creating from other worktrees
- `--no-setup` flag to skip setup
- Continues on errors with warnings

## Configuration Example

```yaml
setup:
  run:
    - cp -r "$GH_WORKTREE_MAIN_DIR/.claude" .
    - cp "$GH_WORKTREE_MAIN_DIR/.env.local" . || true
    - pnpm install
```

## Usage

```bash
# Runs setup automatically
gh worktree pr checkout 1234

# Skip setup
gh worktree pr checkout 1234 --no-setup
```

## Implementation Details

- Added `internal/setup` package with config parsing and setup execution
- Added `GetMainWorktree()` function to detect main worktree using `git worktree list`
- Integrated setup calls after PR and branch worktree creation
- Added comprehensive tests for all functionality

## Test Plan

- [x] Config parsing tests (valid/invalid YAML, empty config)
- [x] Setup execution tests (simple commands, environment variables)
- [x] Main worktree detection test
- [x] Tested with real repository: https://github.com/knqyf263/gh-worktree-test
- [x] Verified setup runs correctly for PR worktrees
- [x] Verified setup runs correctly for branch worktrees
- [x] Verified `--no-setup` flag works
- [x] Verified main worktree detection when creating from other worktrees
- [x] Verified error handling (continues with warnings)