### PR TITLE
fix: output setup messages to stderr in shell mode

### DIFF
--- a/internal/setup/setup.go
+++ b/internal/setup/setup.go
@@ -18,31 +18,31 @@ func RunSetup(newWorktreePath, mainWorktreePath string) error {
 		return nil
 	}
 
-	fmt.Println("→ Running post-creation setup...")
+	fmt.Fprintln(os.Stderr, "→ Running post-creation setup...")
 
 	var warnings []string
 
 	for _, cmdStr := range config.Setup.Run {
-		fmt.Printf("  ✓ %s\n", cmdStr)
+		fmt.Fprintf(os.Stderr, "  ✓ %s\n", cmdStr)
 
 		// Execute command in the new worktree directory with GH_WORKTREE_MAIN_DIR env var
 		cmd := exec.Command("sh", "-c", cmdStr)
 		cmd.Dir = newWorktreePath
 		cmd.Env = append(os.Environ(), fmt.Sprintf("GH_WORKTREE_MAIN_DIR=%s", mainWorktreePath))
-		cmd.Stdout = os.Stdout
+		cmd.Stdout = os.Stderr
 		cmd.Stderr = os.Stderr
 
 		if err := cmd.Run(); err != nil {
 			warning := fmt.Sprintf("Command failed (exit %d): %s", cmd.ProcessState.ExitCode(), cmdStr)
 			warnings = append(warnings, warning)
-			fmt.Printf("  ⚠ %s\n", warning)
+			fmt.Fprintf(os.Stderr, "  ⚠ %s\n", warning)
 		}
 	}
 
 	if len(warnings) > 0 {
-		fmt.Println("  ⚠ Setup completed with warnings")
+		fmt.Fprintln(os.Stderr, "  ⚠ Setup completed with warnings")
 	} else {
-		fmt.Println("  ✓ Setup completed")
+		fmt.Fprintln(os.Stderr, "  ✓ Setup completed")
 	}
 
 	return nil
@@ -59,5 +59,5 @@ func ShouldRunSetup(mainWorktreePath string) bool {
 
 // PrintSkippedMessage prints a message when setup is skipped
 func PrintSkippedMessage() {
-	fmt.Println("  (setup skipped)")
+	fmt.Fprintln(os.Stderr, "  (setup skipped)")
 }


### PR DESCRIPTION
## Summary
- Fixed shell mode to output setup messages to stderr instead of stdout
- This prevents setup output from being captured by `$()` in shell functions

## Problem
When using `--shell` mode with the post-creation setup feature, the setup output was written to stdout and captured by `$(gh worktree pr checkout --shell)`, causing the shell function `ghwc` to fail with "no such file or directory" errors.

## Solution
Changed all setup output to write to stderr (`os.Stderr`). Setup messages are informational and should go to stderr, while only the worktree path should be written to stdout in `--shell` mode.

## Test Plan
- [x] Build and install the extension locally
- [x] Test `ghwc` command with interactive branch creation
- [x] Verify setup output goes to stderr
- [x] Verify only the path is captured by `$()`